### PR TITLE
Fix `run.py` script: execute `app.run()` only if script is called directly

### DIFF
--- a/run.py
+++ b/run.py
@@ -3,10 +3,11 @@
 from app import app
 import os
 
-cwd       = os.getcwd()
-SITE_ROOT = os.path.realpath(os.path.dirname(__file__))
+if __name__ == "__main__":
+    cwd       = os.getcwd()
+    SITE_ROOT = os.path.realpath(os.path.dirname(__file__))
 
-print cwd
-print SITE_ROOT
+    print cwd
+    print SITE_ROOT
 
-app.run(debug=True) ### restart server at every change in code
+    app.run(debug=True) ### restart server at every change in code


### PR DESCRIPTION
This should prevent from executing two Flask instances when calling
`flask run`.
